### PR TITLE
Add RDS Performance Insights arguments [VVM-289]

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,9 @@ Available targets:
 | name | The Name of the application or solution  (e.g. `bastion` or `portal`) | string | - | yes |
 | namespace | Namespace (e.g. `eg` or `cp`) | string | - | yes |
 | parameter_group_name | Name of the DB parameter group to associate | string | `` | no |
+| performance_insights_enabled | Specifies whether Performance Insights are enabled. | bool | `false` | no |
+| performance_insights_kms_key_id | The ARN for the KMS key to encrypt Performance Insights data. Once KMS key is set, it can never be changed. | string | `null` | no |
+| performance_insights_retention_period | The amount of time in days to retain Performance Insights data. Either 7 (7 days) or 731 (2 years). | number | `7` | no |
 | publicly_accessible | Determines if database can be publicly available (NOT recommended) | string | `false` | no |
 | security_group_ids | he IDs of the security groups from which to allow `ingress` traffic to the DB instance | list | `<list>` | no |
 | skip_final_snapshot | If true (default), no snapshot will be made before deleting DB | string | `true` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -30,6 +30,9 @@
 | name | The Name of the application or solution  (e.g. `bastion` or `portal`) | string | - | yes |
 | namespace | Namespace (e.g. `eg` or `cp`) | string | - | yes |
 | parameter_group_name | Name of the DB parameter group to associate | string | `` | no |
+| performance_insights_enabled | Specifies whether Performance Insights are enabled. | bool | `false` | no |
+| performance_insights_kms_key_id | The ARN for the KMS key to encrypt Performance Insights data. Once KMS key is set, it can never be changed. | string | `null` | no |
+| performance_insights_retention_period | The amount of time in days to retain Performance Insights data. Either 7 (7 days) or 731 (2 years). | number | `7` | no |
 | publicly_accessible | Determines if database can be publicly available (NOT recommended) | string | `false` | no |
 | security_group_ids | he IDs of the security groups from which to allow `ingress` traffic to the DB instance | list | `<list>` | no |
 | skip_final_snapshot | If true (default), no snapshot will be made before deleting DB | string | `true` | no |

--- a/main.tf
+++ b/main.tf
@@ -52,6 +52,10 @@ resource "aws_db_instance" "default" {
   monitoring_role_arn         = var.monitoring_role_arn
 
   iam_database_authentication_enabled = var.iam_database_authentication_enabled
+
+  performance_insights_enabled          = var.performance_insights_enabled
+  performance_insights_kms_key_id       = var.performance_insights_enabled ? var.performance_insights_kms_key_id : null
+  performance_insights_retention_period = var.performance_insights_enabled ? var.performance_insights_retention_period : null
 }
 
 resource "aws_db_parameter_group" "default" {

--- a/variables.tf
+++ b/variables.tf
@@ -239,3 +239,20 @@ variable "monitoring_role_arn" {
   default     = ""
 }
 
+variable "performance_insights_enabled" {
+  type        = bool
+  default     = false
+  description = "Specifies whether Performance Insights are enabled."
+}
+
+variable "performance_insights_kms_key_id" {
+  type        = string
+  default     = null
+  description = "The ARN for the KMS key to encrypt Performance Insights data. Once KMS key is set, it can never be changed."
+}
+
+variable "performance_insights_retention_period" {
+  type        = number
+  default     = 7
+  description = "The amount of time in days to retain Performance Insights data. Either 7 (7 days) or 731 (2 years)."
+}


### PR DESCRIPTION
Motivation: Allow to configure Performance Insights for RDS

This is a cherry-pick of https://github.com/cloudposse/terraform-aws-rds/pull/47 so that we can add performance insights config to the terraform config RDS instances.

See JIRA ticket VVM-284